### PR TITLE
Fix compatibility with newer python versions + some other changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: "Determine Branch"
       id: branches
       uses: transferwise/sanitize-branch-name@v1
     - name: Upload artifact to Github
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: OdaTests-${{ steps.branches.outputs.sanitized-branch-name }}.${{ github.run_number }}
         path: |

--- a/odatestcases.py
+++ b/odatestcases.py
@@ -1,24 +1,39 @@
 import unittest
 import asyncio
 import re
+import csv
 from odatests import DemoTest
 
 def clean(varStr) -> str:
-    return re.sub('\W|^(?=\d)','_', varStr)
+    return re.sub(r'\W|^(?=\d)', '_', varStr)
 
 class Test_DemoTest(unittest.IsolatedAsyncioTestCase):
 
+    @staticmethod
     def make_test_function(result):
         def test(self):
             self.assertEqual(True, result)
         return test
 
-    async def run_everything():
-        result = await DemoTest.demolist()
-        for r in result:
-            test_func = Test_DemoTest.make_test_function(r[1])
-            setattr(Test_DemoTest, 'test_{0}'.format(clean(r[0])), test_func)
+async def run_everything():
+    results = await DemoTest.demolist()
+    for r in results:
+        test_func = Test_DemoTest.make_test_function(r[1])
+        setattr(Test_DemoTest, 'test_{0}'.format(clean(r[0])), test_func)
+    
+    total = len(results)
+    passed = sum(1 for _, ok in results if ok)
+    failed = total - passed
+
+    with open("odatests_results_summary.csv", mode="w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=["total", "passed", "failed"])
+        writer.writeheader()
+        writer.writerow({
+            "total": total,
+            "passed": passed,
+            "failed": failed
+        })
 
 if __name__ == '__main__':
-    asyncio.run(Test_DemoTest.run_everything())
-    asyncio.run(unittest.main())
+    asyncio.run(run_everything())
+    unittest.main()

--- a/odatests.py
+++ b/odatests.py
@@ -35,7 +35,7 @@ else:
     TEST_TIMEOUT_SECS = int(os.getenv('TEST_TIMEOUT_SECS'))
 
 if not os.getenv('ODAMEX_BIN'):
-    ODAMEX_BIN = r"C:\Users\Blair\source\repos\odamex-alt\out\build\x64-Debug\client\odamex.exe"
+    ODAMEX_BIN = r"C:\Users\miada\source\repos\odamex\build\client\Debug\odamex.exe"
 else:
     ODAMEX_BIN = os.getenv('ODAMEX_BIN')
 
@@ -152,7 +152,7 @@ class DemoTest ():
             if pwads:
                 args.extend(("-file",) + DemoTest.resolve_wads(pwads))
             if deh:
-                args.extend(("-deh", deh))
+                args.extend(("-deh", DemoTest.resolve_wad(deh)))
             args.extend(("+demotest", DemoTest.resolve_demo(demo)))
 
             # Run Odamex in demotest mode
@@ -197,7 +197,7 @@ class DemoTest ():
             if "pwad" in args:
                 args["pwads"] = args["pwad"].split(" ")
                 del args["pwad"]
-            demotests.append(DemoTest.demotest(procs, section, **args))
+            demotests.append(asyncio.create_task(DemoTest.demotest(procs, section, **args)))
 
         # Run our demo-running coroutines.
         done, _ = await asyncio.wait(
@@ -206,7 +206,7 @@ class DemoTest ():
         results = []
 
         for proc in done:
-                results.append(proc.result())
+            results.append(proc.result())
 
         return results
 


### PR DESCRIPTION
- OdaTests now runs without issue on python 3.11+
- `resolve_wad` is used now to resolve deh files as well. This fixes the chex quest demos, as chex.deh wasn't being found before.
- a csv file containing the number of tests run, passed, and failed is now created for use in the github actions workflows